### PR TITLE
Add 3-day Dependabot cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,3 +24,5 @@ updates:
     schedule:
       # Check for updates to GitHub Actions every weekday
       interval: "weekly"
+    cooldown:
+      default-days: 3


### PR DESCRIPTION
Adds a 3-day cooldown to Dependabot version updates.